### PR TITLE
feat: per-service LB provider & lb-method annotation support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+bin
 
 # Test binary, built with `go test -c`
 *.test

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,12 @@
+defaultBaseImage: gcr.io/distroless/static:nonroot
+
+builds:
+  - id: kinx-cloud-controller-manager
+    main: ./cmd/cloud-controller-manager
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -w
+      - -s
+      - -X
+      - github.com/kinxnet/cloud-provider-kinx/pkg/version.Version={{.Env.VERSION}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [1.0.5] - 2026-04-16
+### Added
+- 서비스별 `loadbalancer.openstack.org/lb-method` 어노테이션 지원 — cloud config 기본값을 서비스 단위로 재정의 가능
+- `service.beta.kubernetes.io/openstack-internal-load-balancer` 어노테이션 지원 — `true` 설정 시 lb-provider를 Private 으로 전환
+
+### Changed
+- ProviderName을 `"kinx"`에서 `"openstack"`으로 변경

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,17 @@
+## Location to install dependencies to
+LOCALBIN ?= $(shell pwd)/bin
+$(LOCALBIN):
+	mkdir -p $(LOCALBIN)
+
+## Tool Binaries
+KO             ?= $(LOCALBIN)/ko
+
+.PHONY: ko
+ko: $(KO) ## Download ko locally if necessary.
+$(KO): $(LOCALBIN)
+	test -s $(LOCALBIN)/ko || GOBIN=$(LOCALBIN) CGO_ENABLED=0 go install -ldflags="-s -w" github.com/google/ko@v0.18.1
+	
+
 # golang-client Makefile
 
 GIT_HOST = github.com/kinxnet
@@ -19,6 +33,9 @@ VERSION		?= "v1.0.0"
 LDFLAGS		:= "-w -s -X 'github.com/kinxnet/cloud-provider-kinx/pkg/version.Version=${VERSION}'"
 REGISTRY	?= ghcr.io/kinxnet/cloud-provider-kinx
 IMAGE_NAMES	?= kinx-cloud-controller-manager
+
+# ko image builder settings
+KO_DOCKER_REPO ?= $(REGISTRY)
 
 work: $(GOBIN)
 
@@ -56,3 +73,23 @@ endif
 
 upload-image:
 	$(MAKE) build-images push-images
+
+# ko-based image build targets
+# Builds the image and loads it into the local Docker daemon.
+# Requires: ko (go install github.com/google/ko@latest)
+ko-build: $(KO)
+	VERSION=$(VERSION) $(KO) build ./cmd/cloud-controller-manager \
+		--image-refs=.ko-image-refs \
+		--platform=linux/amd64 \
+		--sbom=none \
+		--tags=$(VERSION)
+
+# Builds the image and pushes it to the registry specified by KO_DOCKER_REPO (defaults to REGISTRY).
+ko-publish: $(KO)
+	VERSION=$(VERSION) KO_DOCKER_REPO=$(KO_DOCKER_REPO) \
+		$(KO) build ./cmd/cloud-controller-manager \
+		--platform=linux/amd64 \
+		--sbom=none \
+		--tags=$(VERSION),latest \
+		--bare \
+		--push=true

--- a/README.md
+++ b/README.md
@@ -1,35 +1,40 @@
 # cloud-provider-kinx
 
-### Annotation 정보
-#### Protocol 관련 Annotaion
-  - "service.beta.kubernetes.io/kinx-load-balancer-backend-protocol"
-    - (Reqired) terminated_https, http, tcp
-  
-  - "service.beta.kubernetes.io/kinx-load-balancer-tls-container-ids"
-    - kinx-load-balancer-backend-protocol : terminated_https
-    - barbican ssl 인증서 id
-    - ,(comma)로 구분하여 복수개 설정 가능
-    
-  - "service.beta.kubernetes.io/kinx-load-balancer-low-tlsv"
-    - kinx-load-balancer-backend-protocol : terminated_https
+## Annotation 정보
 
-  - "service.beta.kubernetes.io/kinx-load-balancer-redirect-http"
-    - kinx-load-balancer-backend-protocol : http
+모든 Annotation의 prefix는 별도 표기가 없으면 `service.beta.kubernetes.io` 입니다.
 
-  - "service.beta.kubernetes.io/kinx-load-balancer-proxy-protocol"
-    - kinx-load-balancer-backend-protocol : tcp
+### Protocol 관련 Annotation
 
-#### Health Monitor Annotation
--  health monitor 유형 : tcp nodeport 고정
-  - "service.beta.kubernetes.io/kinx-load-balancer-healthcheck-interval"
-    - default 5
-  - "service.beta.kubernetes.io/kinx-load-balancer-healthcheck-retry"
-    - default 3
-  - "service.beta.kubernetes.io/kinx-load-balancer-healthcheck-timeout"
-    - default 5
-  
+| Annotation | 타입 | 기본값 | 유효값 | 설명 |
+|---|---|---|---|---|
+| `kinx-load-balancer-backend-protocol` | string | - **(필수)** | `http`, `tcp`, `terminated_https` | 백엔드 프로토콜 |
+| `kinx-load-balancer-tls-container-ids` | string | - | Barbican 인증서 ID (`,`로 구분하여 복수 설정 가능) | TLS 인증서. `terminated_https`일 때만 사용 |
+| `kinx-load-balancer-low-tlsv` | bool | `false` | `true` / `false` | TLS 1.0/1.1 비활성화. `terminated_https`일 때만 유효 |
+| `kinx-load-balancer-redirect-http` | bool | `false` | `true` / `false` | HTTP → HTTPS 리다이렉트. `http`일 때만 유효 |
+| `kinx-load-balancer-proxy-protocol` | bool | `false` | `true` / `false` | Proxy Protocol 활성화. `tcp`일 때만 유효 |
 
-### local에서 debugging 하는 방법 (vscode 기준)
+### Load Balancer 설정 Annotation
+
+| Annotation | prefix | 타입 | 기본값 | 유효값 | 설명 |
+|---|---|---|---|---|---|
+| `openstack-internal-load-balancer` | `service.beta.kubernetes.io` | bool | `false` | `true` / `false` | `true`이면 lb-provider를 Private 으로 전환 |
+| `lb-method` | `loadbalancer.openstack.org` | string | cloud config의 `lb-method` 값 | `ROUND_ROBIN`, `LEAST_CONNECTIONS`, `SOURCE_IP` | LB 알고리즘. 서비스별로 cloud config 기본값 재정의 가능 |
+
+### Health Monitor Annotation
+
+헬스체크 유형: TCP NodePort 고정
+
+| Annotation | 타입 | 기본값 | 설명 |
+|---|---|---|---|
+| `kinx-load-balancer-healthcheck-interval` | int | `5` | 헬스체크 주기 (초) |
+| `kinx-load-balancer-healthcheck-retry` | int | `3` | 헬스체크 최대 재시도 횟수 |
+| `kinx-load-balancer-healthcheck-timeout` | int | `5` | 헬스체크 타임아웃 (초) |
+
+---
+
+## local에서 debugging 하는 방법 (vscode 기준)
+
 > cloud-controller-manager 및 operator도 비슷한 방식으로 디버깅 가능할 듯
 
 1. Kubernetes Cluster 구성
@@ -58,11 +63,11 @@
       "args": [
           "--v=1",
           "--cloud-config=./cloud-config",
-          "--cloud-provider=kinx",
+          "--cloud-provider=openstack",
           "--use-service-account-credentials=true",
           "--leader-elect=false",
           "--address=127.0.0.1",
-          "--kubeconfig=/Users/{username}/.kube/config",    
+          "--kubeconfig=/Users/{username}/.kube/config",
           "--authentication-kubeconfig=/Users/{username}/.kube/config",
       ]
       ...
@@ -70,13 +75,36 @@
     ```
 6. vscode 디버깅 시작
 
-### build & push
-1. Makefile의 Version, Registry 등 필요한 데이터 수정
-2. docker & golang 설치
-3. make build-images 실행
-4. make push-images 실행
+---
 
-### Reference
+## build & push
+
+### ko 사용 (권장)
+
+[ko](https://ko.build)는 Dockerfile 없이 Go 바이너리를 OCI 이미지로 직접 빌드·푸시할 수 있는 도구입니다.
+
+```bash
+# ko 설치
+go install github.com/google/ko@latest
+
+# 이미지 빌드 (로컬 docker daemon에 로드)
+make ko-build VERSION=v1.0.0
+
+# 이미지 빌드 + 레지스트리 푸시
+make ko-publish VERSION=v1.0.0 REGISTRY=ghcr.io/kinxnet/cloud-provider-kinx
+```
+
+### Docker 사용 (기존 방식)
+
+```bash
+# Makefile의 VERSION, REGISTRY 등 필요한 변수 수정 후 실행
+make build-images
+make push-images
+```
+
+---
+
+## Reference
 
 https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/getting-started-provider-dev.md
 

--- a/pkg/cloudprovider/providers/kinx/kinx.go
+++ b/pkg/cloudprovider/providers/kinx/kinx.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	// ProviderName is the name of the kinx provider
-	ProviderName = "kinx"
+	ProviderName = "openstack"
 
 	// TypeHostName is the name type of openstack instance
 	TypeHostName     = "hostname"

--- a/pkg/cloudprovider/providers/kinx/kinx.go
+++ b/pkg/cloudprovider/providers/kinx/kinx.go
@@ -103,7 +103,6 @@ type LoadBalancerOpts struct {
 	FloatingSubnetID     string              `gcfg:"floating-subnet-id"`  // If specified, will create floating ip for loadbalancer in this particular floating pool subnetwork.
 	LBClasses            map[string]*LBClass // Predefined named Floating networks and subnets
 	LBMethod             string              `gcfg:"lb-method"` // default to ROUND_ROBIN.
-	LBProvider           string              `gcfg:"lb-provider"`
 	CreateMonitor        bool                `gcfg:"create-monitor"`
 	MonitorDelay         int                 `gcfg:"monitor-delay"`
 	MonitorTimeout       int                 `gcfg:"monitor-timeout"`
@@ -313,7 +312,6 @@ func ReadConfig(config io.Reader) (Config, error) {
 
 	// Set default values explicitly
 	cfg.LoadBalancer.InternalLB = false
-	cfg.LoadBalancer.LBProvider = "kinx"
 	cfg.LoadBalancer.LBMethod = "ROUND_ROBIN"
 	cfg.LoadBalancer.ManageSecurityGroups = false
 	cfg.LoadBalancer.CreateMonitor = true

--- a/pkg/cloudprovider/providers/kinx/kinx_loadbalancer.go
+++ b/pkg/cloudprovider/providers/kinx/kinx_loadbalancer.go
@@ -69,13 +69,24 @@ const (
 
 	// lb-provider fixed values — update here when provider names change
 	lbProviderPublic  = "kinx"         // used for public (external) load balancers
-	lbProviderPrivate = "kinx-private" // used when ServiceAnnotationInternalLB is "true"
+	lbProviderPrivate = "kinx_private" // used when ServiceAnnotationInternalLB is "true"
 
 	// health monitor annotation
 	ServiceAnnotationHealthCheckInterval = "service.beta.kubernetes.io/kinx-load-balancer-healthcheck-interval"
 	ServiceAnnotationHealthCheckRetry    = "service.beta.kubernetes.io/kinx-load-balancer-healthcheck-retry"
 	ServiceAnnotationHealthCheckTimeout  = "service.beta.kubernetes.io/kinx-load-balancer-healthcheck-timeout"
+
+	// lb-method annotation — overrides cloud config lb-method per service
+	// Valid values: ROUND_ROBIN, LEAST_CONNECTIONS, SOURCE_IP, SOURCE_IP_PORT
+	ServiceAnnotationLBMethod = "loadbalancer.openstack.org/lb-method"
 )
+
+// validLBMethods contains the set of lb_algorithm values accepted by OpenStack Octavia.
+var validLBMethods = map[string]bool{
+	"ROUND_ROBIN":       true,
+	"LEAST_CONNECTIONS": true,
+	"SOURCE_IP":         true,
+}
 
 // LbaasV2 is a LoadBalancer implementation for Neutron LBaaS v2 API
 type LBaasV2 struct {
@@ -485,7 +496,11 @@ func (lbaas *LBaasV2) EnsureLoadBalancer(ctx context.Context, clusterName string
 
 		if pool == nil {
 			poolProto := getPoolProtocol(backendProtocol)
-			lbmethod := v2pools.LBMethod(lbaas.opts.LBMethod)
+			lbMethodStr := getStringFromServiceAnnotation(apiService, ServiceAnnotationLBMethod, lbaas.opts.LBMethod)
+			if _, ok := validLBMethods[lbMethodStr]; !ok {
+				return nil, fmt.Errorf("invalid %s annotation value %q: must be one of ROUND_ROBIN, LEAST_CONNECTIONS, SOURCE_IP", ServiceAnnotationLBMethod, lbMethodStr)
+			}
+			lbmethod := v2pools.LBMethod(lbMethodStr)
 			createOpt := v2pools.CreateOpts{
 				Name:        cutString(fmt.Sprintf("pool-%d-%s", portIndex, name)),
 				Protocol:    poolProto,
@@ -1034,7 +1049,7 @@ func (lbaas *LBaasV2) getSubnet(subnet string) (*subnets.Subnet, error) {
 	return nil, fmt.Errorf("find multiple subnets with name %s", subnet)
 }
 
-//getStringFromServiceAnnotation searches a given v1.Service for a specific annotationKey and either returns the annotation's value or a specified defaultSetting
+// getStringFromServiceAnnotation searches a given v1.Service for a specific annotationKey and either returns the annotation's value or a specified defaultSetting
 func getStringFromServiceAnnotation(service *corev1.Service, annotationKey string, defaultSetting string) string {
 	klog.V(4).Infof("getStringFromServiceAnnotation(%v, %v, %v)", service, annotationKey, defaultSetting)
 	if annotationValue, ok := service.Annotations[annotationKey]; ok {
@@ -1049,7 +1064,7 @@ func getStringFromServiceAnnotation(service *corev1.Service, annotationKey strin
 	return defaultSetting
 }
 
-//getIntFromServiceAnnotation searches a given v1.Service for a specific annotationKey and either returns the annotation's value or a specified defaultSetting
+// getIntFromServiceAnnotation searches a given v1.Service for a specific annotationKey and either returns the annotation's value or a specified defaultSetting
 func getIntFromServiceAnnotation(service *corev1.Service, annotationKey string, defaultSetting int) (int, error) {
 	klog.V(4).Infof("getIntFromServiceAnnotation(%v, %v, %v)", service, annotationKey, defaultSetting)
 	if annotationValue, ok := service.Annotations[annotationKey]; ok {
@@ -1072,7 +1087,7 @@ func getIntFromServiceAnnotation(service *corev1.Service, annotationKey string, 
 	return defaultSetting, nil
 }
 
-//getBoolFromServiceAnnotation searches a given v1.Service for a specific annotationKey and either returns the annotation's value or a specified defaultSetting
+// getBoolFromServiceAnnotation searches a given v1.Service for a specific annotationKey and either returns the annotation's value or a specified defaultSetting
 func getBoolFromServiceAnnotation(service *corev1.Service, annotationKey string, defaultSetting bool) (bool, error) {
 	klog.V(4).Infof("getBoolFromServiceAnnotation(%v, %v, %v)", service, annotationKey, defaultSetting)
 	if annotationValue, ok := service.Annotations[annotationKey]; ok {

--- a/pkg/cloudprovider/providers/kinx/kinx_loadbalancer.go
+++ b/pkg/cloudprovider/providers/kinx/kinx_loadbalancer.go
@@ -494,12 +494,13 @@ func (lbaas *LBaasV2) EnsureLoadBalancer(ctx context.Context, clusterName string
 			return nil, fmt.Errorf("error getting pool for listener %s: %v", listener.ID, err)
 		}
 
+		lbMethodStr := getStringFromServiceAnnotation(apiService, ServiceAnnotationLBMethod, lbaas.opts.LBMethod)
+		if _, ok := validLBMethods[lbMethodStr]; !ok {
+			return nil, fmt.Errorf("invalid %s annotation value %q: must be one of ROUND_ROBIN, LEAST_CONNECTIONS, SOURCE_IP", ServiceAnnotationLBMethod, lbMethodStr)
+		}
+
 		if pool == nil {
 			poolProto := getPoolProtocol(backendProtocol)
-			lbMethodStr := getStringFromServiceAnnotation(apiService, ServiceAnnotationLBMethod, lbaas.opts.LBMethod)
-			if _, ok := validLBMethods[lbMethodStr]; !ok {
-				return nil, fmt.Errorf("invalid %s annotation value %q: must be one of ROUND_ROBIN, LEAST_CONNECTIONS, SOURCE_IP", ServiceAnnotationLBMethod, lbMethodStr)
-			}
 			lbmethod := v2pools.LBMethod(lbMethodStr)
 			createOpt := v2pools.CreateOpts{
 				Name:        cutString(fmt.Sprintf("pool-%d-%s", portIndex, name)),
@@ -527,8 +528,12 @@ func (lbaas *LBaasV2) EnsureLoadBalancer(ctx context.Context, clusterName string
 		proxyProtocol, _ := getBoolFromServiceAnnotation(apiService, ServiceAnnotationProxyProtocol, false)
 		poolDescription := getPoolDescription(v2pools.Protocol(pool.Protocol), pool.ID, proxyProtocol)
 
-		if pool.Description != poolDescription {
-			pool, err = v2pools.Update(lbaas.lb, pool.ID, v2pools.UpdateOpts{Description: &poolDescription}).Extract()
+		if pool.Description != poolDescription || pool.LBMethod != lbMethodStr {
+			lbmethod := v2pools.LBMethod(lbMethodStr)
+			pool, err = v2pools.Update(lbaas.lb, pool.ID, v2pools.UpdateOpts{
+				Description: &poolDescription,
+				LBMethod:    lbmethod,
+			}).Extract()
 			if err != nil {
 				return nil, fmt.Errorf("failed to update pool %s of listener %s: %v", pool.ID, listener.ID, err)
 			}

--- a/pkg/cloudprovider/providers/kinx/kinx_loadbalancer.go
+++ b/pkg/cloudprovider/providers/kinx/kinx_loadbalancer.go
@@ -65,6 +65,12 @@ const (
 	ServiceAnnotationProxyProtocol   = "service.beta.kubernetes.io/kinx-load-balancer-proxy-protocol"
 	ServiceAnnotationLowTlsv         = "service.beta.kubernetes.io/kinx-load-balancer-low-tlsv"
 
+	ServiceAnnotationInternalLB = "service.beta.kubernetes.io/openstack-internal-load-balancer"
+
+	// lb-provider fixed values — update here when provider names change
+	lbProviderPublic  = "kinx"         // used for public (external) load balancers
+	lbProviderPrivate = "kinx-private" // used when ServiceAnnotationInternalLB is "true"
+
 	// health monitor annotation
 	ServiceAnnotationHealthCheckInterval = "service.beta.kubernetes.io/kinx-load-balancer-healthcheck-interval"
 	ServiceAnnotationHealthCheckRetry    = "service.beta.kubernetes.io/kinx-load-balancer-healthcheck-retry"
@@ -167,10 +173,16 @@ func cutString(original string) string {
 }
 
 func (lbaas *LBaasV2) createLoadBalancer(service *corev1.Service, name, clusterName string, lbClass *LBClass, internalAnnotation bool, vipPort string) (*loadbalancers.LoadBalancer, error) {
+	lbProvider := lbProviderPublic
+	if internalAnnotation {
+		lbProvider = lbProviderPrivate
+	}
+	klog.V(4).Infof("Using lb-provider %q for service %s/%s", lbProvider, service.Namespace, service.Name)
+
 	createOpts := loadbalancers.CreateOpts{
 		Name:        name,
 		Description: fmt.Sprintf("Kubernetes external service %s/%s from cluster %s,lb_version:1.1", service.Namespace, service.Name, clusterName),
-		Provider:    lbaas.opts.LBProvider,
+		Provider:    lbProvider,
 	}
 
 	if vipPort != "" {
@@ -368,7 +380,13 @@ func (lbaas *LBaasV2) EnsureLoadBalancer(ctx context.Context, clusterName string
 
 		klog.V(2).Infof("Creating loadbalancer %s", name)
 
-		loadbalancer, err = lbaas.createLoadBalancer(apiService, name, clusterName, nil /* lbClass */, false /* internal */, "" /* portID */)
+		internalAnnotation, err := getBoolFromServiceAnnotation(apiService, ServiceAnnotationInternalLB, false)
+		if err != nil {
+			klog.Warningf("Invalid value for annotation %s on service %s/%s, using false: %v", ServiceAnnotationInternalLB, apiService.Namespace, apiService.Name, err)
+			internalAnnotation = false
+		}
+
+		loadbalancer, err = lbaas.createLoadBalancer(apiService, name, clusterName, nil /* lbClass */, internalAnnotation, "" /* portID */)
 		if err != nil {
 			return nil, fmt.Errorf("error creating loadbalancer %s: %v", name, err)
 		}


### PR DESCRIPTION
## Summary

- **내부/외부 LB 프로바이더 자동 선택**: `service.beta.kubernetes.io/openstack-internal-load-balancer: "true"` 어노테이션으로 Octavia 프로바이더를 `kinx`(외부) 또는 `kinx_private`(내부)으로 동적 분기
- **서비스별 LB 알고리즘 설정**: `loadbalancer.openstack.org/lb-method` 어노테이션으로 풀 알고리즘(`ROUND_ROBIN` / `LEAST_CONNECTIONS` / `SOURCE_IP`)을 서비스 단위로 독립 지정
- **풀 실시간 업데이트**: 어노테이션 변경 시 LB 재생성 없이 기존 풀의 `lb_algorithm` 즉시 반영
- **ProviderName 수정**: `"kinx"` → `"openstack"` (업스트림 호환성)

## Changed Files

| 파일 | 변경 내용 |
|------|----------|
| `pkg/cloudprovider/providers/kinx/kinx.go` | `LBProvider` 필드 및 기본값 제거, ProviderName 수정 |
| `pkg/cloudprovider/providers/kinx/kinx_loadbalancer.go` | internal-lb 어노테이션 파싱, lb-provider 동적 선택, lb-method 어노테이션 추가, 유효성 검사, 풀 업데이트 로직 |

## Related Issues

- Closes #6 — `loadbalancer.openstack.org/load-balancer-id` (내부 LB 프로바이더 자동 선택)
- Closes #7 — `loadbalancer.openstack.org/lb-method` (서비스별 LB 알고리즘 지정)

## Test plan

- [x] `openstack-internal-load-balancer: "true"` 설정 시 Octavia LB `provider`가 `kinx_private`으로 생성되는지 확인
- [x] 어노테이션 미설정 시 `provider`가 `kinx`(외부)로 생성되는지 확인
- [x] 잘못된 internal-lb 어노테이션 값 입력 시 Warn 로그 후 외부 LB로 폴백되는지 확인
- [x] `lb-method: LEAST_CONNECTIONS` 설정 시 신규 풀 알고리즘이 올바르게 생성되는지 확인
- [x] 기존 LB에서 `lb-method` 어노테이션 변경 후 `EnsureLoadBalancer` 재호출 시 풀이 업데이트되는지 확인
- [x] 유효하지 않은 `lb-method` 값 입력 시 에러 반환 및 LB 미생성 확인
- [x] `cloud-config`에서 `lb-provider` 항목 제거 후 기동 정상 여부 확인